### PR TITLE
Remove keyword locking and enable all 10 keyword fields for all users

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,7 +517,7 @@ h5 {
 
     <!-- Added class to button for specific styling -->
     <button id="submit" class="submit-button">Submit</button>
-    <button id="subscribeButton" class="subscribe-btn">🔑Subscribe to unlock multiple keyword search</button>
+    
     <h3></br><a href="https://t.me/KMupworkbot" target="_blank"> Upwork bot is released @KMupworkbot</h3>
  <h4>&#128073 
   <a href="https://t.me/upworkbotgroup" target="_blank">
@@ -596,27 +596,8 @@ async function loadKeywords(chat_id) {
                 }
             }
 
-            // Handle subscription status & enabling/disabling fields
-            const subscriptionStatus = data.subscription_status;
-            const subscribeButton = document.getElementById("subscribeButton");
-            if (subscribeButton && subscriptionStatus === "paid") {
-                subscribeButton.style.display = "none";
-            }
-
-            const lockedFields = inputFields.slice(3);
-            if (subscriptionStatus !== "paid") {
-                if (data.keywords[0]) {
-                    inputFields[0].value = data.keywords[0];
-                }
-                lockedFields.forEach(field => {
-                    field.disabled = true;
-                    field.placeholder = "🔒"; // lock emoji placeholder
-                    field.value = "";
-                });
-                inputFields.slice(0, 3).forEach(field => (field.disabled = false));
-            } else {
-                inputFields.forEach(field => (field.disabled = false));
-            }
+            // Everyone can edit all 10 keyword fields.
+            inputFields.forEach(field => (field.disabled = false));
 
             // --- Update jobType checkboxes based on fetched data ---
             const jobTypeValues = data.jobType || []; // e.g. ["yes", "yes", "yes"]


### PR DESCRIPTION
### Motivation
- Unsubscribe gating prevented non-paid users from entering more than 3 keywords, but the intent is to allow every user to create up to 10 keywords.

### Description
- Removed the Subscribe/unlock button element from the UI so the page no longer advertises a paid-only unlock control.
- Replaced the subscription-gated locking logic in `loadKeywords` with a single rule that enables all 10 `inputFields` (`inputFields.forEach(field => (field.disabled = false));`).
- Kept existing keyword population and job-type checkbox update logic intact while removing lock placeholders and branch logic for `subscription_status`.

### Testing
- Ran a pattern search `rg -n "subscribeButton|subscription_status|🔒" index.html` and confirmed lock-related tokens were removed from the file.
- Inspected the modified `index.html` to confirm the subscribe button element is gone and that `loadKeywords` unconditionally enables all 10 keyword inputs.
- Verified the change only affects `index.html` and that the new `inputFields` enabling line is present and correctly placed within `loadKeywords`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48bcadd58832aba0c2d7eedd96f4f)